### PR TITLE
Accept member expressions, i.e., `prisma.$queryRaw` as a tag name

### DIFF
--- a/src/rules/format.ts
+++ b/src/rules/format.ts
@@ -17,7 +17,7 @@ export const format = {
 
     return {
       TemplateLiteral(node: any) {
-        if (!node.parent.tag || !tags.includes(node.parent.tag.name)) return;
+        if (!node.parent.tag || !tags.includes(generate(node.parent.tag))) return;
 
         const literal = node.quasis.map((quasi: any) => quasi.value.raw).join(expressionPlaceholder);
 


### PR DESCRIPTION
Currently, the logic for checking matching tag names looks at `parent.tag.name`, which only works if the parent tag node is an `Identifier` node (a single word). For some libraries, like Prisma, the SQL tag is a member of another object, like `Prisma.sql` or `prisma.$queryRaw`. The AST of a tag like that looks something like this:

```json
{
   "type":"MemberExpression",
   "start":12,
   "end":24,
   "object":{
      "type":"Identifier",
      "start":12,
      "end":15,
      "name":"prisma"
   },
   "property":{
      "type":"Identifier",
      "start":16,
      "end":24,
      "name":"$queryRaw"
   },
   "computed":false,
   "optional":false
}
```

This PR runs the `parent.tag` node through astring's `generate` function (already being used in this project) so that we can compare with a string like "prisma.$queryRaw" effectively.